### PR TITLE
Flag dead bills and send notifications

### DIFF
--- a/generateDeadBillAlerts/function.json
+++ b/generateDeadBillAlerts/function.json
@@ -1,0 +1,21 @@
+{
+    "disabled": false,
+    "bindings": [
+        {
+            "queueName": "deadbill",
+            "connection": "ServiceBus.ConnectionString",
+            "name": "bill",
+            "accessRights": "Listen",
+            "type": "serviceBusTrigger",
+            "direction": "in"
+        },
+        {
+            "queueName": "notification",
+            "connection": "ServiceBus.ConnectionString",
+            "name": "notifications",
+            "accessRights": "Listen",
+            "type": "serviceBus",
+            "direction": "out"
+        }
+    ]
+}

--- a/generateDeadBillAlerts/run.fsx
+++ b/generateDeadBillAlerts/run.fsx
@@ -15,11 +15,11 @@ open IgaTracker.Alert
 let deathChamber (action:Action) =
     match (action.ActionType) with
     | ActionType.AssignedToCommittee -> action.Chamber
-    | ActionType.CommitteeReading -> action.Chamber
-    | ActionType.SecondReading -> action.Chamber
-    | ActionType.ThirdReading ->
+    | ActionType.CommitteeReading    -> action.Chamber
+    | ActionType.SecondReading       -> action.Chamber
+    | ActionType.ThirdReading        ->
         match action.Chamber with
-        | Chamber.House -> Chamber.Senate
+        | Chamber.House  -> Chamber.Senate
         | Chamber.Senate -> Chamber.House
         | _ -> failwith ("Unrecognized chamber")
     | _ -> failwith ("Unrecognized action type")
@@ -27,9 +27,9 @@ let deathChamber (action:Action) =
 let deathReason (action:Action) = 
     match (action.ActionType) with
     | ActionType.AssignedToCommittee -> "committee reading"
-    | ActionType.CommitteeReading -> "second reading"
-    | ActionType.SecondReading -> "third reading"
-    | ActionType.ThirdReading -> "committee assignment"
+    | ActionType.CommitteeReading    -> "second reading"
+    | ActionType.SecondReading       -> "third reading"
+    | ActionType.ThirdReading        -> "committee assignment"
     | _ -> failwith ("Unrecognized action type")
 
 // Format a nice description of the action
@@ -37,17 +37,17 @@ let formatBody sessionYear (bill:Bill) action messageType =
     let billName =
         match messageType with 
         | MessageType.Email -> bill.WebLink sessionYear
-        | MessageType.SMS -> Bill.PrettyPrintName bill.Name
+        | MessageType.SMS   -> Bill.PrettyPrintName bill.Name
         | _ -> failwith ("Unknown message type")
 
     let diedInChamber = 
         match action with
-        | None -> bill.Chamber
+        | None    -> bill.Chamber
         | Some(x) -> x |> deathChamber
 
     let diedForReason = 
         match action with
-        | None -> "committee assignment"
+        | None    -> "committee assignment"
         | Some(x) -> x |> deathReason
 
     sprintf "%s ('%s') has died in the %A after failing to receive a %s." billName (bill.Title.TrimEnd('.')) diedInChamber diedForReason

--- a/generateDeadBillAlerts/run.fsx
+++ b/generateDeadBillAlerts/run.fsx
@@ -1,0 +1,92 @@
+#r "System.Data"
+#r "../packages/Dapper/lib/net45/Dapper.dll"
+
+#load "../shared/alert.fsx"
+
+open System
+open System.Data.SqlClient
+open System.Dynamic
+open System.Collections.Generic
+open Dapper
+open IgaTracker.Model
+open IgaTracker.Db
+open IgaTracker.Alert
+
+let deathChamber (action:Action) =
+    match (action.ActionType) with
+    | ActionType.AssignedToCommittee -> action.Chamber
+    | ActionType.CommitteeReading -> action.Chamber
+    | ActionType.SecondReading -> action.Chamber
+    | ActionType.ThirdReading ->
+        match action.Chamber with
+        | Chamber.House -> Chamber.Senate
+        | Chamber.Senate -> Chamber.House
+        | _ -> failwith ("Unrecognized chamber")
+    | _ -> failwith ("Unrecognized action type")
+
+let deathReason (action:Action) = 
+    match (action.ActionType) with
+    | ActionType.AssignedToCommittee -> "committee reading"
+    | ActionType.CommitteeReading -> "second reading"
+    | ActionType.SecondReading -> "third reading"
+    | ActionType.ThirdReading -> "committee assignment"
+    | _ -> failwith ("Unrecognized action type")
+
+// Format a nice description of the action
+let formatBody sessionYear (bill:Bill) action messageType =
+    let billName =
+        match messageType with 
+        | MessageType.Email -> bill.WebLink sessionYear
+        | MessageType.SMS -> Bill.PrettyPrintName bill.Name
+        | _ -> failwith ("Unknown message type")
+
+    let diedInChamber = 
+        match action with
+        | None -> bill.Chamber
+        | Some(x) -> x |> deathChamber
+
+    let diedForReason = 
+        match action with
+        | None -> "committee assignment"
+        | Some(x) -> x |> deathReason
+
+    sprintf "%s ('%s') has died in the %A after failing to receive a %s." billName (bill.Title.TrimEnd('.')) diedInChamber diedForReason
+
+// Create action alert messages for people that have opted-in to receiving them
+let generateAlerts (bill:Bill) =
+    let cn = new SqlConnection(System.Environment.GetEnvironmentVariable("SqlServer.ConnectionString"))
+    let sessionYear = cn |> currentSessionYear
+    let mostRecentAction = cn |> dapperParametrizedQuery<Action> "SELECT TOP 1 * FROM Action WHERE BillId = @Id ORDER BY Date DESC" {Id=bill.Id} |> Seq.tryHead
+    let emailBody = formatBody sessionYear bill mostRecentAction MessageType.Email
+    let smsBody = formatBody sessionYear bill mostRecentAction MessageType.SMS
+    cn |> generateAlertsForBill bill (emailBody,smsBody)
+
+
+// Azure function entry point
+
+#r "../packages/Microsoft.Azure.WebJobs/lib/net45/Microsoft.Azure.WebJobs.Host.dll"
+#r "../packages/Microsoft.Azure.WebJobs.Core/lib/net45/Microsoft.Azure.WebJobs.dll"
+#r "../packages/Newtonsoft.Json/lib/net45/Newtonsoft.Json.dll"
+
+open Microsoft.Azure.WebJobs
+open Microsoft.Azure.WebJobs.Host
+open Newtonsoft.Json
+
+let Run(bill: string, notifications: ICollector<string>, log: TraceWriter) =
+    log.Info(sprintf "F# function executed for action %s at %s" bill (timestamp()))
+    try
+        log.Info(sprintf "[%s] Generating dead bill alerts ..." (timestamp()))
+        let messages = JsonConvert.DeserializeObject<Bill>(bill) |> generateAlerts
+        log.Info(sprintf "[%s] Generating dead bill alerts [OK]" (timestamp()))
+
+        log.Info(sprintf "[%s] Enqueueing dead bill alerts ..." (timestamp()))
+        let enqueue msg = 
+            let json = msg |> JsonConvert.SerializeObject
+            log.Info(sprintf "[%s]   Enqueuing dead bill alert: %s" (timestamp()) json )
+            json |> notifications.Add
+        messages |> List.iter enqueue
+        log.Info(sprintf "[%s] Enqueueing dead bill alerts [OK]" (timestamp()))
+    with
+    | ex -> 
+        log.Error(sprintf "[%s] Encountered error: %s" (timestamp()) (ex.ToString())) 
+        reraise()

--- a/scaffolding/createDbTables.sql
+++ b/scaffolding/createDbTables.sql
@@ -45,7 +45,8 @@ CREATE TABLE Bill
     Authors nvarchar(256),
     Chamber TINYINT NOT NULL,
     Created DATETIME NOT NULL DEFAULT GetUtcDate(),
-    SessionId int NOT NULL FOREIGN KEY REFERENCES [Session](Id)
+    SessionId int NOT NULL FOREIGN KEY REFERENCES [Session](Id),
+    IsDead bit NOT NULL DEFAULT 0
 )
 
 CREATE TABLE [Action]

--- a/shared/model.fs
+++ b/shared/model.fs
@@ -52,6 +52,7 @@ module Model =
         Authors:string;
         Chamber:Chamber; 
         SessionId:int; 
+        IsDead:bool;
     } with
         static member ParseNumber (billName:string) = billName.Substring(2,4).TrimStart('0')        
         static member PrettyPrintName (billName:string) = sprintf "%s %s" (billName.Substring(0,2)) (Bill.ParseNumber billName)

--- a/shared/queries.fs
+++ b/shared/queries.fs
@@ -179,8 +179,8 @@ WHERE
 		DigestType = 1 
 		AND EXISTS (SELECT 1 FROM UserBill ub WHERE ub.UserId = u.Id))"""
 
-	[<Literal>]
-	let FetchNewDeadBills = """DECLARE @date Date
+    [<Literal>]
+    let FetchNewDeadBills = """DECLARE @date Date
 SET @date = GetDate()
 SELECT b.Id
 FROM Bill b
@@ -210,5 +210,8 @@ WHERE
 			AND (@date < '2017-04-06' OR EXISTS (SELECT a.Id from Action a where a.BillId = b.Id AND a.Chamber = 1 AND a.ActionType = 3 AND a.Description like '%passed%'))
 		)
 	)
-	AND LEFT(Name,2) IN ('HB', 'SB')
-	"""
+	AND LEFT(Name,2) IN ('HB', 'SB')"""
+
+    [<Literal>]
+    let UpdateDeadBills = """UPDATE Bill SET IsDead = 1 WHERE Id IN @Ids; 
+SELECT Id, Name FROM Bill WHERE Id IN @Ids"""

--- a/shared/queries.fs
+++ b/shared/queries.fs
@@ -178,3 +178,37 @@ WHERE
 	OR (
 		DigestType = 1 
 		AND EXISTS (SELECT 1 FROM UserBill ub WHERE ub.UserId = u.Id))"""
+
+	[<Literal>]
+	let FetchNewDeadBills = """DECLARE @date Date
+SET @date = GetDate()
+SELECT b.Id
+FROM Bill b
+WHERE
+	b.Dead = 0 
+	AND b.SessionId = (SELECT TOP 1 Id FROM Session ORDER BY Name Desc)
+	AND NOT ( 
+		b.Chamber = 1 AND
+		(
+				(@date < '2017-02-21' OR EXISTS (SELECT a.Id from Action a where a.BillId = b.Id AND a.Chamber = 1 AND a.ActionType = 1 AND a.Description like '%adopted%'))
+			AND (@date < '2017-02-23' OR EXISTS (SELECT a.Id from Action a where a.BillId = b.Id AND a.Chamber = 1 AND a.ActionType = 2 AND a.Description like '%engrossed%'))
+			AND (@date < '2017-02-27' OR EXISTS (SELECT a.Id from Action a where a.BillId = b.Id AND a.Chamber = 1 AND a.ActionType = 3 AND a.Description like '%passed%'))
+			AND (@date < '2017-04-03' OR EXISTS (SELECT a.Id from Action a where a.BillId = b.Id AND a.Chamber = 2 AND a.ActionType = 1 AND a.Description like '%adopted%'))
+			AND (@date < '2017-04-05' OR EXISTS (SELECT a.Id from Action a where a.BillId = b.Id AND a.Chamber = 2 AND a.ActionType = 2 AND a.Description like '%engrossed%'))
+			AND (@date < '2017-04-06' OR EXISTS (SELECT a.Id from Action a where a.BillId = b.Id AND a.Chamber = 2 AND a.ActionType = 3 AND a.Description like '%passed%'))
+		)
+	)
+	AND	NOT (
+		b.Chamber = 2 AND
+		(
+				(@date < '2017-01-19' OR EXISTS (SELECT a.Id from Action a where a.BillId = b.Id AND a.Chamber = 2 AND a.ActionType = 4))
+			AND	(@date < '2017-02-23' OR EXISTS (SELECT a.Id from Action a where a.BillId = b.Id AND a.Chamber = 2 AND a.ActionType = 1 AND a.Description like '%adopted%'))
+			AND (@date < '2017-02-27' OR EXISTS (SELECT a.Id from Action a where a.BillId = b.Id AND a.Chamber = 2 AND a.ActionType = 2 AND a.Description like '%engrossed%'))
+			AND (@date < '2017-02-28' OR EXISTS (SELECT a.Id from Action a where a.BillId = b.Id AND a.Chamber = 2 AND a.ActionType = 3 AND a.Description like '%passed%'))
+			AND (@date < '2017-04-03' OR EXISTS (SELECT a.Id from Action a where a.BillId = b.Id AND a.Chamber = 1 AND a.ActionType = 1 AND a.Description like '%adopted%'))
+			AND (@date < '2017-04-05' OR EXISTS (SELECT a.Id from Action a where a.BillId = b.Id AND a.Chamber = 1 AND a.ActionType = 2 AND a.Description like '%engrossed%'))
+			AND (@date < '2017-04-06' OR EXISTS (SELECT a.Id from Action a where a.BillId = b.Id AND a.Chamber = 1 AND a.ActionType = 3 AND a.Description like '%passed%'))
+		)
+	)
+	AND LEFT(Name,2) IN ('HB', 'SB')
+	"""

--- a/test/alertTests.fsx
+++ b/test/alertTests.fsx
@@ -7,7 +7,7 @@ open FsUnit
 open IgaTracker.Model
 open IgaTracker.Alert
 
-let bill = {Bill.Id=1; Name="HB1001"; Title="HB 1001 title"; Chamber=Chamber.House; Description="desc"; Authors="auth"; Link="link"; SessionId=0;}
+let bill = {Bill.Id=1; Name="HB1001"; Title="HB 1001 title"; Chamber=Chamber.House; Description="desc"; Authors="auth"; Link="link"; SessionId=0; IsDead=false;}
 let users = 
     [{User.Id=1; Name="johnny"; Email="johnny@gmail.com"; Mobile="+11112223333"; DigestType=DigestType.MyBills };
     {User.Id=2; Name="susie"; Email="jimmy@gmail.com"; Mobile="+12223334444"; DigestType=DigestType.MyBills };]

--- a/test/deadBillAlertTest.fsx
+++ b/test/deadBillAlertTest.fsx
@@ -1,0 +1,69 @@
+#load "../shared/model.fs"
+#load "../generateDeadBillAlerts/run.fsx"
+#r "../packages/Nunit/lib/net45/nunit.framework.dll"
+#r "../packages/FsUnit/lib/net45/FsUnit.NUnit.dll"
+
+open System
+open NUnit.Framework
+open FsUnit
+open IgaTracker.Model
+open Run
+let genericAction = {Action.Chamber=Chamber.House; Date=System.DateTime(2000,1,1); ActionType=ActionType.CommitteeReading; Description="";  Id=0;BillId=0;Link="";}
+let houseBill = {Bill.Chamber=Chamber.House; Name="HB1000"; Title="Title"; Description="Description"; Link="Link"; Authors="Authors"; Id=0; SessionId=0; IsDead=true;}
+let senateBill = {Bill.Chamber=Chamber.Senate; Name="SB0001"; Title="Title"; Description="Description"; Link="Link"; Authors="Authors"; Id=0; SessionId=0; IsDead=true;}
+
+[<TestFixture>]
+type ``died in the House``()=
+
+    [<Test>] 
+    let ``because did not receive house committee reading``()=
+        let mostRecentAction = Some({genericAction with ActionType=ActionType.AssignedToCommittee; Chamber=Chamber.House })
+        formatBody "2017" houseBill mostRecentAction MessageType.SMS |> should equal "HB 1000 ('Title') has died in the House after failing to receive a committee reading."
+
+    [<Test>] 
+    let ``because did not receive house second reading``()=
+        let mostRecentAction = Some({genericAction with ActionType=ActionType.CommitteeReading; Chamber=Chamber.House})
+        formatBody "2017" houseBill mostRecentAction MessageType.SMS |> should equal "HB 1000 ('Title') has died in the House after failing to receive a second reading."
+
+    [<Test>] 
+    let ``because did not receive house third reading``()=
+        let mostRecentAction = Some({genericAction with ActionType=ActionType.SecondReading; Chamber=Chamber.House})
+        formatBody "2017" houseBill mostRecentAction MessageType.SMS |> should equal "HB 1000 ('Title') has died in the House after failing to receive a third reading."        
+
+    [<Test>] 
+    let ``because did not receive house committee assignment (house bill)``()=
+        let mostRecentAction = None
+        formatBody "2017" houseBill mostRecentAction MessageType.SMS |> should equal "HB 1000 ('Title') has died in the House after failing to receive a committee assignment."
+
+    [<Test>] 
+    let ``because did not receive house committee assignment (senate bill)``()=
+        let mostRecentAction = Some({genericAction with ActionType=ActionType.ThirdReading; Chamber=Chamber.Senate})
+        formatBody "2017" senateBill mostRecentAction MessageType.SMS |> should equal "SB 1 ('Title') has died in the House after failing to receive a committee assignment."
+
+[<TestFixture>]
+type ``died in the Senate``()=
+
+    [<Test>] 
+    let ``because did not receive senate committee reading``()=
+        let mostRecentAction = Some({genericAction with ActionType=ActionType.AssignedToCommittee; Chamber=Chamber.Senate})
+        formatBody "2017" senateBill mostRecentAction MessageType.SMS |> should equal "SB 1 ('Title') has died in the Senate after failing to receive a committee reading."
+
+    [<Test>] 
+    let ``because did not receive senate second reading``()=
+        let mostRecentAction = Some({genericAction with ActionType=ActionType.CommitteeReading; Chamber=Chamber.Senate})
+        formatBody "2017" senateBill mostRecentAction MessageType.SMS |> should equal "SB 1 ('Title') has died in the Senate after failing to receive a second reading."
+
+    [<Test>] 
+    let ``because did not receive senate third reading``()=
+        let mostRecentAction = Some({genericAction with ActionType=ActionType.SecondReading; Chamber=Chamber.Senate})
+        formatBody "2017" senateBill mostRecentAction MessageType.SMS |> should equal "SB 1 ('Title') has died in the Senate after failing to receive a third reading."        
+
+    [<Test>] 
+    let ``because did not receive senate committee assignment (house bill)``()=
+        let mostRecentAction = Some({genericAction with ActionType=ActionType.ThirdReading; Chamber=Chamber.House})
+        formatBody "2017" houseBill mostRecentAction MessageType.SMS |> should equal "HB 1000 ('Title') has died in the Senate after failing to receive a committee assignment."
+
+    [<Test>] 
+    let ``because did not receive senate committee assignment (senate bill)``()=
+        let mostRecentAction = None
+        formatBody "2017" senateBill mostRecentAction MessageType.SMS |> should equal "SB 1 ('Title') has died in the Senate after failing to receive a committee assignment."

--- a/updateCanonicalData/run.fsx
+++ b/updateCanonicalData/run.fsx
@@ -67,7 +67,8 @@ let updateBills cn =
         Title=bill?latestVersion?shortDescription.AsString(); 
         Description= bill?latestVersion?digest.AsString();
         Chamber=parseChamber name;
-        Authors=bill?latestVersion?authors.AsArray() |> Array.toList |> List.map (fun a -> a?lastName.AsString()) |> List.sort |> String.concat ", "; }
+        Authors=bill?latestVersion?authors.AsArray() |> Array.toList |> List.map (fun a -> a?lastName.AsString()) |> List.sort |> String.concat ", ";
+        IsDead = false }
 
     // Find new bills
     let knownBills = cn |> dapperQuery<string> "SELECT Name from Bill WHERE SessionId = (SELECT TOP 1 Id FROM Session ORDER BY Name Desc)"

--- a/updateDeadBills/function.json
+++ b/updateDeadBills/function.json
@@ -1,0 +1,19 @@
+{
+    "disabled": false,
+    "bindings": [
+        {
+            "name": "myTimer",
+            "type": "timerTrigger",
+            "direction": "in",
+            "schedule": "0 30 8 * * 1-5"
+        },
+        {
+            "queueName": "deadbill",
+            "connection": "ServiceBus.ConnectionString",
+            "name": "deadbills",
+            "accessRights": "Listen",
+            "type": "serviceBus",
+            "direction": "out"
+        }
+    ]
+}

--- a/updateDeadBills/run.fsx
+++ b/updateDeadBills/run.fsx
@@ -1,0 +1,61 @@
+
+#r "System.Data"
+#r "../packages/Dapper/lib/net45/Dapper.dll"
+#r "../packages/StackExchange.Redis/lib/net45/StackExchange.Redis.dll"
+
+#load "../shared/model.fs"
+#load "../shared/queries.fs"
+#load "../shared/db.fsx"
+#load "../shared/cache.fsx"
+
+open System
+open System.Data.SqlClient
+open System.Dynamic
+open System.Collections.Generic
+open Dapper
+open IgaTracker.Model
+open IgaTracker.Db
+open IgaTracker.Queries
+open IgaTracker.Cache
+
+let getNewDeadBills cn = 
+    let deadBillIds = cn |> dapperQuery<int> FetchNewDeadBills
+    cn |> dapperMapParametrizedQuery<Bill> UpdateDeadBills (Map ["Ids", deadBillIds :> obj])
+
+// Azure Function entry point
+
+#r "../packages/Microsoft.Azure.WebJobs.Core/lib/net45/Microsoft.Azure.WebJobs.dll"
+#r "../packages/Microsoft.Azure.WebJobs/lib/net45/Microsoft.Azure.WebJobs.Host.dll"
+#r "../packages/Microsoft.Azure.WebJobs.Extensions/lib/net45/Microsoft.Azure.WebJobs.Extensions.dll"
+#r "../packages/Newtonsoft.Json/lib/net45/Newtonsoft.Json.dll"
+
+open Microsoft.Azure.WebJobs
+open Microsoft.Azure.WebJobs.Host
+open Microsoft.Azure.WebJobs.Extensions
+open Newtonsoft.Json
+
+let Run(myTimer: TimerInfo, deadbills: ICollector<string>, log: TraceWriter) =
+    log.Info(sprintf "F# function executed at: %s" (timestamp()))
+    try
+        let cn = new SqlConnection((sqlConStr()))
+        
+        log.Info(sprintf "[%s] Fetching newly dead bills ..." (timestamp()))
+        let deadBills = cn |> getNewDeadBills
+        log.Info(sprintf "[%s] Fetching newly dead bills [OK]" (timestamp()))
+
+        log.Info(sprintf "[%s] Enqueue alerts for newly dead bills ..." (timestamp()))
+        deadBills 
+            |> Seq.map JsonConvert.SerializeObject 
+            |> Seq.iter (fun json ->
+                log.Info(sprintf "[%s]  Enqueuing action %s" (timestamp()) json)
+                json |> deadbills.Add)
+        log.Info(sprintf "[%s] Enqueue alerts for newly dead bills [OK]" (timestamp()))
+
+        log.Info(sprintf "[%s] Invalidating cache ..." (timestamp()))
+        deadBills |> invalidateCache BillsKey
+        log.Info(sprintf "[%s] Invalidating cache [OK]" (timestamp()))
+
+    with
+    | ex -> 
+        log.Error(sprintf "Encountered error: %s" (ex.ToString())) 
+        reraise()


### PR DESCRIPTION
Determine when a bill has failed to reach certain legislative milestones. This PR covers scenarios of failure by omission; that is, when a bill is _not brought up_ for a reading/vote, as opposed to when a bill _fails_ a vote. Send a notification to watchers of the bill.

We determine that a bill has died by checking for the absence of specific actions following their corresponding legislative deadlines. Notifications will be sent out the evening of the legislative day on which the bill has died.

Closes #1, #3