### PR TITLE
Update canonical data more frequently

### DIFF
--- a/updateCanonicalData/function.json
+++ b/updateCanonicalData/function.json
@@ -5,7 +5,7 @@
             "name": "myTimer",
             "type": "timerTrigger",
             "direction": "in",
-            "schedule": "0 30 7 * * 1-5"
+            "schedule": "0 5-59/10 7-20 * * 1-5"
         }
     ]
 }


### PR DESCRIPTION
Change from once a day on weekday mornings to every 10 minutes during the weekday. This will resolve referential errors that can occur when actions / scheduled actions refer to committees  or bills that were just added to data source.