### PR TITLE
Update bill metadata when adding new actions

### DIFF
--- a/scaffolding/createDbTables.sql
+++ b/scaffolding/createDbTables.sql
@@ -46,7 +46,8 @@ CREATE TABLE Bill
     Chamber TINYINT NOT NULL,
     Created DATETIME NOT NULL DEFAULT GetUtcDate(),
     SessionId int NOT NULL FOREIGN KEY REFERENCES [Session](Id),
-    IsDead bit NOT NULL DEFAULT 0
+    IsDead bit NOT NULL DEFAULT 0,
+    [Version] int NOT NULL Default 1
 )
 
 CREATE TABLE [Action]

--- a/shared/bill.fsx
+++ b/shared/bill.fsx
@@ -61,8 +61,9 @@ SELECT * FROM Bill WHERE Name = @Name AND SessionId = (SELECT TOP 1 Id FROM Sess
         let newBillModel = bill |> toModel
         cn |> dapperParameterizedQueryOne<Bill> QueryInsertBill newBillModel
 
-    let updateBillToLatest (billName:string) cn =
+    let updateBillToLatest id cn =
         let sessionYear = cn |> currentSessionYear
+        let billName = cn |> dapperParameterizedQueryOne<string> "SELECT Name FROM Bill where Id = @Id" {Id=id}
         let billMetadata = get (sprintf "/%s/bills/%s" sessionYear (billName.ToLower()))
         let latestBillModel = billMetadata |> toModel
         let recordedBillModel = cn |> dapperParameterizedQueryOne<Bill> QuerySelectBillByName latestBillModel

--- a/shared/bill.fsx
+++ b/shared/bill.fsx
@@ -1,0 +1,74 @@
+namespace IgaTracker
+
+#load "../shared/logging.fsx"
+#r "../packages/Microsoft.ApplicationInsights/lib/net45/Microsoft.ApplicationInsights.dll"
+
+#r "System.Data"
+#r "../packages/Dapper/lib/net45/Dapper.dll"
+#r "../packages/FSharp.Data/lib/portable-net45+sl50+netcore45/FSharp.Data.dll"
+#r "../packages/StackExchange.Redis/lib/net45/StackExchange.Redis.dll"
+
+#load "../shared/model.fs"
+#load "../shared/http.fsx"
+#load "../shared/db.fsx"
+#load "../shared/cache.fsx"
+
+module Bill =
+
+    open System
+    open System.Data.SqlClient
+    open System.Dynamic
+    open System.Collections.Generic
+    open Dapper
+    open FSharp.Data
+    open FSharp.Data.JsonExtensions
+    open IgaTracker.Model
+    open IgaTracker.Http
+    open IgaTracker.Db
+    open IgaTracker.Cache
+    open IgaTracker.Logging
+
+    [<Literal>]
+    let QuerySelectBillByName = """SELECT * FROM Bill 
+WHERE Name = @Name AND SessionId = (SELECT TOP 1 Id FROM Session ORDER BY Name Desc)"""        
+
+    [<Literal>]
+    let QueryInsertBill = """INSERT INTO Bill(Name,Link,Title,Description,Authors,Chamber,SessionId) 
+VALUES (@Name,@Link,@Title,@Description,@Authors,@Chamber,(SELECT TOP 1 Id FROM Session ORDER BY Name Desc)); 
+SELECT * FROM Bill WHERE ID = (CAST(SCOPE_IDENTITY() as int);"""
+
+    [<Literal>]
+    let QueryUpdateBillByName = """UPDATE Bill
+SET Title = @Title
+	, Description = @Description
+	, Authors = @Authors
+WHERE Name = @Name AND SessionId = (SELECT TOP 1 Id FROM Session ORDER BY Name Desc);
+SELECT * FROM Bill WHERE Name = @Name AND SessionId = (SELECT TOP 1 Id FROM Session ORDER BY Name Desc);"""
+
+    let toModel bill = 
+        { Bill.Id=0; 
+        SessionId=0; 
+        Name=bill?billName.AsString(); 
+        Link=bill?link.AsString(); 
+        Title=bill?latestVersion?shortDescription.AsString(); 
+        Description=bill?latestVersion?digest.AsString();
+        Chamber=(if bill?originChamber.AsString() = "house" then Chamber.House else Chamber.Senate);
+        Authors=bill?latestVersion?authors.AsArray() |> Array.toList |> List.map (fun a -> a?lastName.AsString()) |> List.sort |> String.concat ", ";
+        IsDead=false;
+        Version=bill?printVersion.AsInteger() }
+    
+    let insertBill bill cn = 
+        let newBillModel = bill |> toModel
+        cn |> dapperParameterizedQueryOne<Bill> QueryInsertBill newBillModel
+
+    let updateBillToLatest (billName:string) cn =
+        let sessionYear = cn |> currentSessionYear
+        let billMetadata = get (sprintf "/%s/bills/%s" sessionYear (billName.ToLower()))
+        let latestBillModel = billMetadata |> toModel
+        let recordedBillModel = cn |> dapperParameterizedQueryOne<Bill> QuerySelectBillByName latestBillModel
+        match latestBillModel.Version with
+        | x when x = recordedBillModel.Version -> 
+            recordedBillModel
+        | _ -> 
+            delete BillsKey
+            cn |> dapperParameterizedQueryOne<Bill> QueryUpdateBillByName latestBillModel

--- a/shared/bill.fsx
+++ b/shared/bill.fsx
@@ -71,5 +71,6 @@ SELECT * FROM Bill WHERE Name = @Name AND SessionId = (SELECT TOP 1 Id FROM Sess
         | x when x = recordedBillModel.Version -> 
             recordedBillModel
         | _ -> 
+            trackTrace "Bill" (sprintf "Updating metadata for %s from version %d to version %d" billName recordedBillModel.Version latestBillModel.Version)
             delete BillsKey
             cn |> dapperParameterizedQueryOne<Bill> QueryUpdateBillByName latestBillModel

--- a/shared/db.fsx
+++ b/shared/db.fsx
@@ -31,8 +31,14 @@ module Db =
             expandoDictionary.Add(paramValue.Key, paramValue.Value :> obj)
         connection |> dapperParametrizedQuery query expando
     
+    let dapperParameterizedQueryOne<'Result> (query:string) (param:obj) connection =
+        connection |> dapperParametrizedQuery<'Result> query param |> Seq.head
+
+    let dapperQueryOne<'Result> (query:string) connection =
+        connection |> dapperQuery<'Result> query |> Seq.head
+
     let currentSessionYear cn = 
-        cn |> dapperQuery<string> "SELECT TOP 1 Name FROM Session ORDER BY Name Desc" |> Seq.head
+        cn |> dapperQueryOne<string> "SELECT TOP 1 Name FROM Session ORDER BY Name Desc"
 
     let currentSessionId cn = 
-        cn |> dapperQuery<int> "SELECT TOP 1 Id FROM Session ORDER BY Name Desc" |> Seq.head
+        cn |> dapperQueryOne<int> "SELECT TOP 1 Id FROM Session ORDER BY Name Desc"

--- a/shared/model.fs
+++ b/shared/model.fs
@@ -63,6 +63,7 @@ module Model =
         Chamber:Chamber; 
         SessionId:int; 
         IsDead:bool;
+        Version:int;
     } with
         static member ParseNumber (billName:string) = billName.Substring(2,4).TrimStart('0')        
         static member PrettyPrintName (billName:string) = sprintf "%s %s" (billName.Substring(0,2)) (Bill.ParseNumber billName)

--- a/shared/queries.fs
+++ b/shared/queries.fs
@@ -13,11 +13,6 @@ VALUES (@Link,@Date,@ActionType,@Start,@End,@Location,@Chamber,@BillId);
 SELECT CAST(SCOPE_IDENTITY() as int)"""
 
     [<Literal>]
-    let InsertBill= """INSERT INTO Bill(Name,Link,Title,Description,Authors,Chamber,SessionId) 
-VALUES (@Name,@Link,@Title,@Description,@Authors,@Chamber,@SessionId); 
-SELECT CAST(SCOPE_IDENTITY() as int)"""
-
-    [<Literal>]
     let InsertCommittee= """INSERT INTO Committee(Name,Link,Chamber,SessionId) 
 VALUES (@Name,@Link,@Chamber,@SessionId); 
 SELECT CAST(SCOPE_IDENTITY() as int)"""

--- a/updateActions/run.fsx
+++ b/updateActions/run.fsx
@@ -11,6 +11,7 @@
 #load "../shared/db.fsx"
 #load "../shared/http.fsx"
 #load "../shared/cache.fsx"
+#load "../shared/bill.fsx"
 
 open System
 open System.Data.SqlClient
@@ -25,6 +26,7 @@ open IgaTracker.Db
 open IgaTracker.Queries
 open IgaTracker.Cache
 open IgaTracker.Logging
+open IgaTracker.Bill
 
 let toActionModel (action,bill:Bill) = {
     Action.Id = 0;
@@ -51,13 +53,18 @@ let createNewActionModels (cn:SqlConnection) allActions =
         |> List.map (actionAndBill >> toActionModel)
         |> List.filter toKnownActionTypes
 
+let ensureLatestBillMetadata (actions:Action list) cn =
+    actions 
+    |> Seq.map (fun a -> cn |> updateBillToLatest a.BillId) 
+    |> ignore   
+
 let addToDatabase (cn:SqlConnection) models =
-    let addActionToDbAndGetId (action:Action) = cn |> dapperParametrizedQuery<int> InsertAction action |> Seq.head
+    let addActionToDbAndGetId (action:Action) = cn |> dapperParameterizedQueryOne<int> InsertAction action
     let fetchActionsRequiringAlert insertedIds = cn |> dapperMapParametrizedQuery<Action> SelectActionsRequiringNotification (Map ["Ids", insertedIds :> obj])
 
     models
-        |> List.map addActionToDbAndGetId
-        |> fetchActionsRequiringAlert 
+    |> List.map addActionToDbAndGetId
+    |> fetchActionsRequiringAlert 
 
 
 // Azure Function entry point
@@ -87,6 +94,10 @@ let Run(myTimer: TimerInfo, actions: ICollector<string>, log: TraceWriter) =
         log.Info(sprintf "[%s] Adding actions to database ..." (timestamp()))
         let actionIdsRequiringAlert = actionModels |> addToDatabase cn
         log.Info(sprintf "[%s] Adding actions to database [OK]" (timestamp()))
+
+        log.Info(sprintf "[%s] Ensuring latest bill metadata in database ..." (timestamp()))
+        cn |> ensureLatestBillMetadata actionModels
+        log.Info(sprintf "[%s] Ensuring latest bill metadata in database [OK]" (timestamp()))
 
         log.Info(sprintf "[%s] Enqueue alerts for new actions ..." (timestamp()))
         let enqueue json =


### PR DESCRIPTION
Bill info (title/description) can change over time and the API does not offer a good way to query for these changes. In this PR we start checking for updated bill information every time we look for new actions and scheduled actions. (The latter might be overkill, but it's _at worst_ overkill.)