### PR TITLE
Add bill signing/veto events to Legislative Update

### DIFF
--- a/generateDigest/run.fsx
+++ b/generateDigest/run.fsx
@@ -59,27 +59,26 @@ let printSectionTitle actionType =
     | ActionType.VetoOverridden -> "Vetoes Overridden"
     | _ -> ""
 
-
 // ACTIONS
 let listAction (a:DigestAction) = 
     sprintf "* [%s](https://iga.in.gov/legislative/%s/bills/%s/%s) ('%s'): %s" (Bill.PrettyPrintName a.BillName) a.SessionName (a.BillChamber.ToString().ToLower()) (Bill.ParseNumber a.BillName) a.Title a.Description
 
 let listActions (actions:DigestAction seq) =
-    match actions with 
-    | seq when Seq.isEmpty seq -> "(None)"
-    | seq -> 
-        seq
-        |> Seq.sortBy (fun action -> action.BillName)
-        |> Seq.map listAction
-        |> String.concat "\n"
+    actions
+    |> Seq.sortBy (fun a -> a.BillName)
+    |> Seq.map listAction
+    |> String.concat "\n"
 
-let describeActions (chamber, actionType) (actions:DigestAction seq) = 
+let describeActions chamber actionType (actions:DigestAction seq) = 
     let sectionTitle = sprintf "###%s  " (printSectionTitle actionType)
     let section = 
         actions 
-        |> Seq.filter (fun action -> action.ActionChamber = chamber && action.ActionType = actionType) 
+        |> Seq.filter (fun a -> a.ActionChamber = chamber && a.ActionType = actionType) 
         |> listActions
-    [sectionTitle; section]
+
+    match section with
+    | EmptySeq -> []
+    | _ -> [sectionTitle; section]
 
 let describeActionsForChamber chamber (actions:DigestAction seq) = 
     let header = sprintf "##Today's %A Activity  " chamber
@@ -112,10 +111,10 @@ let listScheduledActions (scheduledActions:DigestScheduledAction seq) =
 let describeScheduledActions actionType (actions:DigestScheduledAction seq) = 
     let actionsOfType = actions |> Seq.filter (fun action -> action.ActionType = actionType)
     match actionsOfType with
-    | sequence when Seq.isEmpty sequence -> []
-    | sequence ->
+    | EmptySeq -> []
+    | _ ->
         let sectionTitle = sprintf "###%s  " (printSectionTitle actionType)
-        let section = sequence |> listScheduledActions
+        let section = actionsOfType |> listScheduledActions
         [sectionTitle; section]
 
 let describeScheduledActionsForDay (date:DateTime,scheduledActions) = 

--- a/generateDigest/run.fsx
+++ b/generateDigest/run.fsx
@@ -53,6 +53,10 @@ let printSectionTitle actionType =
     | ActionType.CommitteeReading -> "Committee Hearings"
     | ActionType.SecondReading -> "Second Readings"
     | ActionType.ThirdReading -> "Third Readings"
+    | ActionType.SignedByPresidentOfSenate -> "Bills Sent to Governor"
+    | ActionType.SignedByGovernor -> "Bills Signed by the Governor"
+    | ActionType.VetoedByGovernor -> "Bills Vetoed by the Governor"
+    | ActionType.VetoOverridden -> "Vetoes Overridden"
     | _ -> ""
 
 
@@ -79,10 +83,18 @@ let describeActions (chamber, actionType) (actions:DigestAction seq) =
 
 let describeActionsForChamber chamber (actions:DigestAction seq) = 
     let header = sprintf "##Today's %A Activity  " chamber
-    let committeReports = actions |> describeActions (chamber, ActionType.CommitteeReading)
-    let secondReadings = actions |> describeActions (chamber, ActionType.SecondReading)
-    let thirdReadings = actions |> describeActions (chamber, ActionType.ThirdReading)
-    [header] @ committeReports @ secondReadings @ thirdReadings
+    match actions with
+    | EmptySeq -> 
+        [header] @ ["(None)"]
+    | _ ->
+        [header] 
+        @ (actions |> describeActions chamber ActionType.CommitteeReading)
+        @ (actions |> describeActions chamber ActionType.SecondReading)
+        @ (actions |> describeActions chamber ActionType.ThirdReading)
+        @ (actions |> describeActions chamber ActionType.SignedByPresidentOfSenate)
+        @ (actions |> describeActions chamber ActionType.SignedByGovernor)
+        @ (actions |> describeActions chamber ActionType.VetoedByGovernor)
+        @ (actions |> describeActions chamber ActionType.VetoOverridden)
 
 // SCHEDULED ACTIONS
 let listScheduledAction sa =

--- a/shared/model.fs
+++ b/shared/model.fs
@@ -7,6 +7,9 @@ module Model =
             Some(s.Substring(p.Length))
         else
             None
+    
+    let (|EmptySeq|_|) a = 
+        if Seq.isEmpty a then Some () else None
 
     let timestamp() = System.DateTime.Now.ToString("HH:mm:ss.fff")
     let datestamp() = System.DateTime.Now.ToString("yyyy-MM-dd")


### PR DESCRIPTION
This PR adds bill signing/veto events to Legislative Update. It also makes a subtle format change to the Update: empty sections ("(None)") will no longer be included to reduce visual clutter.