### PR TITLE
Log notification delivery; prevent duplicate notification delivery

### DIFF
--- a/src/Functions/Common/Core.fs
+++ b/src/Functions/Common/Core.fs
@@ -50,7 +50,9 @@ type WorkFlowFailure =
     | RequestValidationError of string
     | NextStepResolution of string
     | EntityAlreadyExists
+    | NotificationAlreadyDelivered
     | NotificationGenerationError of string
+    | NotificationDeliveryError of string
     | BadRequestError of string
 
 type NextWorkflow = NextWorkflow of Workflow seq
@@ -173,27 +175,42 @@ let chooseBoth (items:list<('a*'b option)>) =
         | None -> None)
     |> List.choose id
 
-let inline flatten source msgs = 
+let inline flatten msgs = 
     msgs 
     |> Seq.map (fun wf -> wf.ToString())
     |> String.concat "\n" 
-    |> sprintf "%A\n%s" source
+
+let logStart (log: TraceWriter) cmd =
+    sprintf "[Start] [%A]" cmd 
+    |> log.Info
+
+let logFinish cmd (stopwatch:Diagnostics.Stopwatch) logger label msg =
+    sprintf "[%s] [%A] (%d ms) %s" label cmd stopwatch.ElapsedMilliseconds msg
+    |> logger
 
 /// Log succesful or failed completion of the function, along with any warnings.
-let executeWorkflow (log:TraceWriter) source (workflow: unit -> Next) = 
+let executeWorkflow (log:TraceWriter) source workflow =
+    logStart log source
+    let logFinish = logFinish source (Diagnostics.Stopwatch.StartNew())
     let result = workflow()
     match result with
     | Fail (errs) -> 
-        errs |> flatten source |> log.Warning
-    | Warn (NextWorkflow steps, errs) ->  
-        errs |> flatten source |> log.Warning        
-    | Pass (NextWorkflow steps) -> ()            
+        errs |> flatten |> logFinish log.Error "Error"
+    | Warn (_, errs) ->  
+        errs |> flatten |> logFinish log.Warning "Warning"       
+    | Pass (_) -> logFinish log.Info "Success" ""
     result
+
+let throwErrors source errs =
+    errs 
+    |> flatten 
+    |> sprintf "[Error] [%A]:\n%s" source 
+    |> Exception 
+    |> raise
 
 let throwOnFail source result =
     match result with
-    | Fail (errs) ->
-        errs |> flatten source |> Exception |> raise
+    | Fail (errs) -> throwErrors source errs
     | _ -> ignore
 
 let inline enqueue (queue:ICollector<string>) items =
@@ -207,27 +224,25 @@ let inline tryEnqueue (queue:ICollector<string>) items =
         items
     tryFail op EnqueueFailure
 
-let enqueueNext log enqueue result =
+let enqueueNext (log:TraceWriter) source enqueue result =
     match result with
     | Ok (NextWorkflow next, _) ->
         match next with 
         | EmptySeq    -> 
-            "Success. This is a terminal step"
-            |> log
+            sprintf "[NextState] [%A] This is a terminal step." source
+            |> log.Info
             |> ignore
         | steps ->
             steps 
             |> Seq.map (fun n -> n.ToString())
             |> String.concat "\n"
-            |> sprintf "Success. Next steps:\n%s"
-            |> log
+            |> sprintf "[NextState] [%A] Next steps:\n%s" source
+            |> log.Info
             steps
             |> enqueue
-    | Bad _ ->
-        "Failed. Enqueueing no next step."
-        |> log
-        |> ignore
-    result
+        result
+    | _ -> 
+        result
 
 let inline workflowTerminates result = 
     match result with
@@ -244,7 +259,7 @@ let inline workflowContinues steps result =
     | Bad msgs ->       
         Next.FailWith(msgs)
 
-let deserializeQueueItem<'t> (log: TraceWriter) str =
+let inline deserializeQueueItem<'t> (log: TraceWriter) str =
     let error e =
         e
         |> timestamped 

--- a/src/Functions/Common/Formatting.fs
+++ b/src/Functions/Common/Formatting.fs
@@ -65,3 +65,10 @@ let formatEventTime startTime endTime customStart =
 
 let formatCommitteeName chamber committeeName = 
     sprintf "%A %s Committee" chamber committeeName
+
+let sha256Hash (str:string) = 
+    str
+    |> System.Text.Encoding.UTF8.GetBytes
+    |> System.Security.Cryptography.SHA256Managed.Create().ComputeHash
+    |> Array.map (fun b -> b.ToString("x2").ToUpper())
+    |> String.concat ""

--- a/src/Functions/Common/Model.fs
+++ b/src/Functions/Common/Model.fs
@@ -178,6 +178,14 @@ type Message = {
 }
 
 [<CLIMutable>]
+type NotificationLog = {
+    MessageType:MessageType;
+    Recipient:string;
+    Subject:string;
+    Digest:string;
+}
+
+[<CLIMutable>]
 type Recipient = {
     Email:string;
     Mobile:string;

--- a/src/Functions/Notification/Notification.fs
+++ b/src/Functions/Notification/Notification.fs
@@ -3,12 +3,18 @@
 open Microsoft.Azure.WebJobs.Host
 open Ptp.Core
 open Ptp.Model
+open Ptp.Database
+open Chessie.ErrorHandling
 open FSharp.Markdown
 open SendGrid;
 open SendGrid.Helpers.Mail
 open Twilio;
 open Twilio.Rest.Api.V2010.Account;
 open Twilio.Types;
+open System.Security.Cryptography
+open System.Text
+open Newtonsoft.Json
+open Ptp.Core
 
 let ptpLogoMarkup = """
     <img alt="Ping the People logo" src="https://pingthepeopleprod.blob.core.windows.net/images/ptplogo.PNG" />
@@ -16,37 +22,97 @@ let ptpLogoMarkup = """
     <br/>
  """
 
-let sendMail msg = 
-    let apiKey = env "SendGrid.ApiKey"
-    let fromAddr = env "SendGrid.FromAddr"
-    let fromName = env "SendGrid.FromName" 
-    let from = EmailAddress(fromAddr, fromName)
-    let toAddr = msg.Recipient |> EmailAddress
-    let subject = msg.Subject
-    let textContent = msg.Body
-    let htmlContent = ptpLogoMarkup + (msg.Body |> Markdown.Parse |> Markdown.WriteHtml)
-    let mail = MailHelper.CreateSingleEmail(from, toAddr, subject, textContent, htmlContent)
-    SendGridClient(apiKey).SendEmailAsync(mail).Wait()
+let sendMail (msg:Message) = 
+    let op() =
+        let apiKey = env "SendGrid.ApiKey"
+        let fromAddr = env "SendGrid.FromAddr"
+        let fromName = env "SendGrid.FromName" 
+        let from = EmailAddress(fromAddr, fromName)
+        let toAddr = msg.Recipient |> EmailAddress
+        let subject = msg.Subject
+        let textContent = msg.Body
+        let htmlContent = ptpLogoMarkup + (msg.Body |> Markdown.Parse |> Markdown.WriteHtml)
+        let mail = MailHelper.CreateSingleEmail(from, toAddr, subject, textContent, htmlContent)
+        SendGridClient(apiKey).SendEmailAsync(mail).Wait() |> ignore
+        msg
+    tryFail op NotificationDeliveryError
 
-let sendSms msg = 
-    let body = sprintf "[Ping the People] %s" msg.Body
-    let accountSid = env "Twilio.AccountSid"
-    let authToken = env "Twilio.AuthToken"
-    let fromNumber = env "Twilio.From"
-    TwilioClient.Init(accountSid, authToken)
-    let toNumber = PhoneNumber(msg.Recipient)
-    let fromNumber = PhoneNumber(fromNumber)
-    MessageResource.Create(``to``=toNumber, from=fromNumber, body=body) |> ignore
+let sendSms (msg:Message) = 
+    let op() =
+        let body = sprintf "[Ping the People] %s" msg.Body
+        let accountSid = env "Twilio.AccountSid"
+        let authToken = env "Twilio.AuthToken"
+        let fromNumber = env "Twilio.From"
+        TwilioClient.Init(accountSid, authToken)
+        let toNumber = PhoneNumber(msg.Recipient)
+        let fromNumber = PhoneNumber(fromNumber)
+        MessageResource.Create(``to``=toNumber, from=fromNumber, body=body) |> ignore
+        msg
+    tryFail op NotificationDeliveryError
 
+let digest (str:string) = 
+    str
+    |> Encoding.UTF8.GetBytes
+    |> SHA256Managed.Create().ComputeHash
+    |> Array.map (fun b -> b.ToString("x2").ToUpper())
+    |> String.concat ""
+    
+let tryLogDeliveryQuery = """
+    INSERT INTO NotificationLog (Recipient,MessageType,Subject,Digest,UserId)
+    VALUES (@Recipient
+           ,@MessageType
+           ,@Subject
+           ,@Digest
+           ,( SELECT Id FROM users
+              WHERE (@MessageType=1 AND Email=@Recipient)
+                 OR (@MessageType=2 AND Mobile=@Recipient)))
+"""
+
+let generateLog msg = 
+    let op()=
+        let log = 
+          { Digest=(digest msg.Body)
+            MessageType=msg.MessageType
+            Recipient=msg.Recipient
+            Subject=msg.Subject }
+        (msg,log)
+    tryFail op NotificationGenerationError
+
+let logDelivery (msg,log) = trial {
+    let! id = dbParameterizedQueryOne<int> tryLogDeliveryQuery log
+    return (msg,id)
+}
+
+
+let deliver sendMail sendSms (msg:Message) =
+    match msg.MessageType with
+    | MessageType.Email ->  msg |> sendMail
+    | MessageType.SMS ->    msg |> sendSms
+    | _ -> 
+        sprintf "Unrecognized message type '%A'" msg.MessageType
+        |> NotificationDeliveryError
+        |> fail   
+        
+let evaluateResult desc result = 
+    match result with
+    | Fail errs -> throwErrors desc errs
+    | _ -> ()
+
+let workflow logDelivery sendSms sendMail msg = 
+    fun () ->
+        generateLog msg
+        >>= logDelivery
+        >>= deliver sendMail sendSms    
+    
 let Run(log: TraceWriter, notification: string) =
-    match deserializeQueueItem<Message> log notification with
-    | Some msg -> 
-        sprintf "Sending %A to %s re: %s" msg.MessageType msg.Recipient msg.Subject
-        |> log.Info
-        match msg.MessageType with
-        | MessageType.Email ->  msg |> sendMail
-        | MessageType.SMS ->    msg |> sendSms
-        | _ ->
-            sprintf "Unrecognized message type '%A'" msg.MessageType
-            |> failwith
-    | None -> ()
+    match notification with
+    | null -> 
+        "Dequeued empty message" 
+        |> log.Warning
+    | n ->
+        let msg = n |> JsonConvert.DeserializeObject<Message>
+        let desc = sprintf "Notification (%A to: '%s' re: '%s')" msg.MessageType msg.Recipient msg.Subject
+        workflow logDelivery sendSms sendMail msg
+        |> executeWorkflow log desc
+        |> evaluateResult desc
+        |> ignore

--- a/src/Functions/Scaffolding/createDbTables.sql
+++ b/src/Functions/Scaffolding/createDbTables.sql
@@ -93,6 +93,17 @@ CREATE TABLE Legislator
     SessionId int NOT NULL FOREIGN KEY REFERENCES [Session](Id)
 )
 
+CREATE TABLE NotificationLog
+(
+    Id int IDENTITY(1,1) PRIMARY KEY,
+	UserId int NOT NULL FOREIGN KEY REFERENCES [users](Id),
+	MessageType TINYINT NOT NULL,
+    Recipient nvarchar(256) NOT NULL,
+	Subject nvarchar(512) NOT NULL,
+	[Digest] nvarchar(128) NOT NULL,
+	Created DATETIME NOT NULL DEFAULT GetUtcDate(),	
+)
+
 -- Many-to-many tables
 
 Create Table UserBill

--- a/src/Functions/Scaffolding/createDbTables.sql
+++ b/src/Functions/Scaffolding/createDbTables.sql
@@ -99,9 +99,10 @@ CREATE TABLE NotificationLog
 	UserId int NOT NULL FOREIGN KEY REFERENCES [users](Id),
 	MessageType TINYINT NOT NULL,
     Recipient nvarchar(256) NOT NULL,
-	Subject nvarchar(512) NOT NULL,
-	[Digest] nvarchar(128) NOT NULL,
+	Subject nvarchar(256) NOT NULL,
+	[Digest] nchar(64) NOT NULL,
 	Created DATETIME NOT NULL DEFAULT GetUtcDate(),	
+    CONSTRAINT AK_Notification UNIQUE(Digest)
 )
 
 -- Many-to-many tables

--- a/test/Functions.Tests/FormattingTests.fs
+++ b/test/Functions.Tests/FormattingTests.fs
@@ -19,3 +19,9 @@ let ``formats start time``() =
 [<Fact>]
 let ``formats date``() =
     test <@ formatEventDate (System.DateTime(2018,1,5)) = "Friday, 5 Jan 2018" @>
+
+[<Fact>]
+let ``generates message digest``()=
+    let testBody = "this is the message body"
+    let expectedHash = "95F1C48D1EDD2CB36B099F999E94FCC4BB0462FA4F8E6B650F0A94EEC4BA493E"
+    test <@ sha256Hash testBody = expectedHash @>

--- a/test/Functions.Tests/Functions.Tests.fsproj
+++ b/test/Functions.Tests/Functions.Tests.fsproj
@@ -64,6 +64,7 @@
     <Compile Include="WorkflowTests.fs" />
     <Compile Include="Workflow.SubjectTests.fs" />
     <Compile Include="Workflow.CommitteeTests.fs" />
+    <Compile Include="NotificationTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Chessie">

--- a/test/Functions.Tests/NotificationTests.fs
+++ b/test/Functions.Tests/NotificationTests.fs
@@ -1,0 +1,70 @@
+﻿module NotificationTests
+
+open Swensen.Unquote
+open Xunit
+open Xunit.Abstractions
+open Ptp.Http
+open Ptp.Core
+open Ptp.Model
+open Ptp.Notification
+open Chessie.ErrorHandling
+open Newtonsoft.Json
+
+let testBody = "this is the message body"
+let expectedHash = "95F1C48D1EDD2CB36B099F999E94FCC4BB0462FA4F8E6B650F0A94EEC4BA493E"
+let testMsg = 
+  { MessageType = MessageType.Email
+    Subject = "Email to foo regarding bar"
+    Body = testBody
+    Recipient = ""
+    Attachment = "" }
+let testMail = {testMsg with MessageType=MessageType.Email; Recipient="user@ptp.org"}
+let testSms =  {testMsg with MessageType=MessageType.SMS; Recipient="+12345678901"}
+
+// successful functions
+let sendMsgOk x = ok ""
+let logDeliveryOk (msg,x) = ok (msg,1)
+
+[<Fact>]
+let ``generates message digest``()=
+    test <@ Function.digest testBody = expectedHash @>
+
+[<Fact>]
+let ``generates log object``() =
+    let expectedLog =
+      { MessageType=MessageType.Email
+        Digest=expectedHash
+        Recipient="user@pingthepeople.org"
+        Subject="Email to foo regarding bar" }
+    test <@ Function.generateLog testMail = Result.Ok((testMail,expectedLog),[]) @>
+
+[<Fact>]
+let ``fails if notification already sent``() =
+    let logDelivery (msg,x) = ok (msg,0)
+    let testWorkflow = Function.workflow logDelivery sendMsgOk sendMsgOk testMail
+    test <@ testWorkflow() = Result.Bad([NotificationAlreadyDelivered]) @>
+
+[<Fact>]
+let ``send email msg ok``()=
+    let sendSmsFail x = failwith "Should have sent email"
+    let testWorkflow = Function.workflow logDeliveryOk sendSmsFail sendMsgOk testMail
+    test <@ testWorkflow() = Result.Ok("",[]) @>
+    
+[<Fact>]
+let ``send email msg fail``()=
+    let sendEmailFail x = "fail!" |> NotificationDeliveryError |> fail
+    let testWorkflow = Function.workflow logDeliveryOk sendMsgOk sendEmailFail testMail 
+    test <@ testWorkflow() = Result.Bad([NotificationDeliveryError("fail!")]) @>
+
+[<Fact>]
+let ``send sms msg ok``()=
+    let sendEmailFail x = failwith "Should have sent sms"
+    let testWorkflow = Function.workflow logDeliveryOk sendMsgOk sendEmailFail testSms
+    test <@ testWorkflow() = Result.Ok("",[]) @>
+    
+[<Fact>]
+let ``send sms msg fail``()=
+    let sendSmsFail x = "fail!" |> NotificationDeliveryError |> fail
+    let testWorkflow = Function.workflow logDeliveryOk sendSmsFail sendMsgOk testSms
+    test <@ testWorkflow() = Result.Bad([NotificationDeliveryError("fail!")]) @>
+    

--- a/test/Functions.Tests/NotificationTests.fs
+++ b/test/Functions.Tests/NotificationTests.fs
@@ -23,24 +23,11 @@ let testSms =  {testMsg with MessageType=MessageType.SMS; Recipient="+1234567890
 
 // successful functions
 let sendMsgOk x = ok ""
-let logDeliveryOk (msg,x) = ok (msg,1)
-
-[<Fact>]
-let ``generates message digest``()=
-    test <@ Function.digest testBody = expectedHash @>
-
-[<Fact>]
-let ``generates log object``() =
-    let expectedLog =
-      { MessageType=MessageType.Email
-        Digest=expectedHash
-        Recipient="user@pingthepeople.org"
-        Subject="Email to foo regarding bar" }
-    test <@ Function.generateLog testMail = Result.Ok((testMail,expectedLog),[]) @>
+let logDeliveryOk (msg,x) = ok (msg,Some("inserted"))
 
 [<Fact>]
 let ``fails if notification already sent``() =
-    let logDelivery (msg,x) = ok (msg,0)
+    let logDelivery (msg,x) = ok (msg,None)
     let testWorkflow = Function.workflow logDelivery sendMsgOk sendMsgOk testMail
     test <@ testWorkflow() = Result.Bad([NotificationAlreadyDelivered]) @>
 


### PR DESCRIPTION
I discovered an [issue with the Azure Functions runtime](https://github.com/Azure/azure-webjobs-sdk-script/issues/2309) that could result in functions being erroneously re-run. This PR adds a table to log delivery of notifications, along with a query that will prevent redelivery of notifications by comparing message hashes. The function must successfully insert a row into this table in order to proceed with delivery. The MERGE feature of SQL server I'm using here can replace instances of the "if exists then ignore else insert" pattern found elsewhere in the code.

This table is also nice to have just so we have a record of how many notifications we're sending 
out. This will be a good number to have at some point.

Also improves and refactors some logging.

Fixes #26.